### PR TITLE
Fixed static references for initializeClient

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -133,9 +133,9 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected static function initializeClient()
     {
-        return self::createClient(
+        return static::createClient(
             array('environment' => static::ENVIRONMENT),
-            self::getServerParameters()
+            static::getServerParameters()
         );
     }
 


### PR DESCRIPTION
When overriding getServerParameters or createClient, we need to call the overridden function, not the one defined in WebTestCase.
