### PR TITLE
Allow commands to run without input

### DIFF
--- a/Test/Helper/CommandHelper.php
+++ b/Test/Helper/CommandHelper.php
@@ -86,11 +86,11 @@ class CommandHelper extends AbstractHelper
     /**
      * Execute a console command.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Input\InputInterface|null $input
      *
      * @return string
      */
-    public function run(InputInterface $input)
+    public function run(InputInterface $input = null)
     {
         $handler = fopen('php://temp/maxmemory:' . $this->maxMemory, 'r+');
         $output  = new StreamOutput($handler);


### PR DESCRIPTION
Some commands do not require input, this will allow you to call run() without bothering to create the inputs required otherwise.
