### PR TITLE
Reference key should be optional for data fixtures.

### DIFF
--- a/DataFixtures/AbstractFixtureCreate.php
+++ b/DataFixtures/AbstractFixtureCreate.php
@@ -34,6 +34,10 @@ abstract class AbstractFixtureCreate extends AbstractFixture
 
             $manager->persist($entity);
 
+            if (is_int($referenceKey)) {
+                continue;
+            }
+
             $this->setReference($referenceKey, $entity);
         }
 


### PR DESCRIPTION
For example, when a data fixture has no dependencies.
