### PR TITLE
Fix mysql 5.5 truncate problem

### DIFF
--- a/Test/Loader/FixtureLoader.php
+++ b/Test/Loader/FixtureLoader.php
@@ -43,7 +43,7 @@ class FixtureLoader
     public function __construct(Client $client)
     {
         $this->client    = $client;
-        $this->purgeMode = ORMPurger::PURGE_MODE_TRUNCATE;
+        $this->purgeMode = ORMPurger::PURGE_MODE_DELETE;
     }
 
     /**


### PR DESCRIPTION
MySQL 5.5 can not truncate tables with foreign keys so we must use delete. see also https://github.com/doctrine/DoctrineFixturesBundle/issues/50
