### PR TITLE
getEntityManager() to getManager() in fixtures loader

### DIFF
--- a/Test/Loader/FixtureLoader.php
+++ b/Test/Loader/FixtureLoader.php
@@ -71,7 +71,7 @@ class FixtureLoader
     {
         $container       = $this->client->getContainer();
         $managerRegistry = $container->get('doctrine');
-        $entityManager   = $managerRegistry->getEntityManager($managerName);
+        $entityManager   = $managerRegistry->getManager($managerName);
 
         // Preparing executor
         $executor = $this->prepareExecutor($entityManager);


### PR DESCRIPTION
Because it is `@deprecated`.
