### PR TITLE
Save session cookie in SessionHelper after authentication

### DIFF
--- a/Test/Helper/SessionHelper.php
+++ b/Test/Helper/SessionHelper.php
@@ -89,6 +89,8 @@ class SessionHelper extends AbstractHelper
 
         $this->session->set('_security_' . $firewall, serialize($token));
         $this->session->save();
+        
+        $this->client->getCookieJar()->set(new Cookie($this->session->getName(), $this->session->getId()));
     }
 
     /**


### PR DESCRIPTION
According to this:
http://symfony.com/doc/current/cookbook/testing/simulating_authentication.html
and this:
https://github.com/bamarni/symfony-standard/commit/317ce94dd7db092e24ac5ebf96e5eefb79c37497#commitcomment-2953995

we have to "create the cookie AFTER the session is saved". Without that the authentication does not work for me.
