### PR TITLE
Add constant to be able to change purge mode for fixtures.

### DIFF
--- a/Test/Functional/WebTestCase.php
+++ b/Test/Functional/WebTestCase.php
@@ -6,6 +6,7 @@
 namespace IC\Bundle\Base\TestBundle\Test\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use IC\Bundle\Base\TestBundle\Test\Loader;
 
@@ -23,6 +24,8 @@ abstract class WebTestCase extends BaseWebTestCase
     const ENVIRONMENT = 'test';
 
     const MANAGER_NAME = null;
+
+    const FIXTURES_PURGE_MODE = ORMPurger::PURGE_MODE_DELETE;
 
     /**
      * @var boolean
@@ -56,7 +59,7 @@ abstract class WebTestCase extends BaseWebTestCase
             return;
         }
 
-        $fixtureLoader = new Loader\FixtureLoader($this->client);
+        $fixtureLoader = new Loader\FixtureLoader($this->client, static::FIXTURES_PURGE_MODE);
         $executor      = $fixtureLoader->load(static::MANAGER_NAME, $fixtureList);
 
         $this->referenceRepository = $executor->getReferenceRepository();

--- a/Test/Loader/FixtureLoader.php
+++ b/Test/Loader/FixtureLoader.php
@@ -40,10 +40,10 @@ class FixtureLoader
      *
      * @param \Symfony\Bundle\FrameworkBundle\Client $client
      */
-    public function __construct(Client $client)
+    public function __construct(Client $client, $purgeMode = ORMPurger::PURGE_MODE_DELETE)
     {
         $this->client    = $client;
-        $this->purgeMode = ORMPurger::PURGE_MODE_DELETE;
+        $this->purgeMode = $purgeMode;
     }
 
     /**


### PR DESCRIPTION
Since ID resetting is a MUST for db dependent  functional testing, having the ability to use `ORMPurger::PURGE_MODE_TRUNCATE` is something that should be considered.
