### PR TITLE
Allow client options to be configured in tests.

### DIFF
--- a/Test/Functional/WebTestCase.php
+++ b/Test/Functional/WebTestCase.php
@@ -157,9 +157,19 @@ abstract class WebTestCase extends BaseWebTestCase
     protected static function initializeClient()
     {
         return static::createClient(
-            array('environment' => static::ENVIRONMENT),
+            static::getClientOptions(),
             static::getServerParameters()
         );
+    }
+
+    /**
+     * Overwritable method for client's options
+     *
+     * @return array
+     */
+    protected static function getClientOptions()
+    {
+        return array('environment' => static::ENVIRONMENT);
     }
 
     /**


### PR DESCRIPTION
Writing some functional tests for a bundle (instead of an app) and I need to be able to configure test cases to have different client options.

I made this change given getServerParameters() is already there - if this is undesired I can just override initializeClient() instead.
